### PR TITLE
Use js_app.html as the landing page for Chrome-Devtools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,26 @@ CMAKE_MINIMUM_REQUIRED (VERSION 2.8)
 
 PROJECT (v8inspector)
 
-INCLUDE (FindV8.cmake)
-INCLUDE (FindICU.cmake)
+#INCLUDE (FindV8.cmake)
+#INCLUDE (FindICU.cmake)
 INCLUDE (FindLZ.cmake)
-INCLUDE (FindLIBUV.cmake)
+#INCLUDE (FindLIBUV.cmake)
 INCLUDE (FindOPENSSL.cmake)
 
-INCLUDE_DIRECTORIES( ${ICU_INCLUDE_DIR}
-                     ${LIBUV_INCLUDE_DIR}
+SET(V8_INCLUDE_DIR /Users/gautham/.cbdepscache/include)
+SET(V8_LIBRARIES
+        /Users/gautham/.cbdepscache/lib/libv8.dylib
+        /Users/gautham/.cbdepscache/lib/libv8_libplatform.dylib
+        /Users/gautham/.cbdepscache/lib/libv8_libbase.dylib)
+
+SET(ICU_LIBRARIES
+        /Users/gautham/.cbdepscache/lib/libicui18n.dylib
+        /Users/gautham/.cbdepscache/lib/libicuuc.dylib)
+
+SET(LIBUV_LIBRARIES
+        /Users/gautham/.cbdepscache/lib/libuv.dylib)
+
+INCLUDE_DIRECTORIES(
                      ${V8_INCLUDE_DIR}
                      ${OPENSSL_INCLUDE_DIR}
                      ${V8_INCLUDE_DIR}/include

--- a/inspector_socket_server.cc
+++ b/inspector_socket_server.cc
@@ -124,7 +124,7 @@ void PrintDebuggerReadyMessage(const std::string& host,
   for (const std::string& id : ids) {
     std::string frontend_url;
     frontend_url = "chrome-devtools://devtools/bundled";
-    frontend_url += "/inspector.html?experiments=true&v8only=true&ws=";
+    frontend_url += "/js_app.html?experiments=true&v8only=true&ws=";
     frontend_url += FormatWsAddress(host, port, id, false);
     fprintf(out, "%s\n", frontend_url.c_str());
     fprintf(stderr, "Debugger starting on %s\n", frontend_url.c_str());
@@ -402,7 +402,7 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket) {
       GetSocketHost(&socket->tcp, &host);
       std::ostringstream frontend_url;
       frontend_url << "chrome-devtools://devtools/bundled";
-      frontend_url << "/inspector.html?experiments=true&v8only=true&ws=";
+      frontend_url << "/js_app.html?experiments=true&v8only=true&ws=";
       frontend_url << FormatWsAddress(host, port, id, false);
       target_map["devtoolsFrontendUrl"] += frontend_url.str();
       target_map["webSocketDebuggerUrl"] =


### PR DESCRIPTION
As per https://github.com/nodejs/node/pull/21385 the landing
page for Chrome-Devtools has been changed to js_app.html